### PR TITLE
docs: load optimize ad tag as the carbon ads fallback option

### DIFF
--- a/packages/docs/src/components/app/Banner.vue
+++ b/packages/docs/src/components/app/Banner.vue
@@ -4,7 +4,7 @@
     id="app-banner-bar"
     :color="banner.metadata.color"
     :height="height"
-    :image="banner.metadata.images.bg.url"
+    :image="banner.metadata.images.bg?.url"
     :theme="banner.metadata.theme.key"
     :model-value="hasPromotion"
     flat
@@ -17,12 +17,12 @@
       v-bind="banner.metadata.attributes"
       @click="onClick"
     >
-      <v-list-item lines="three">
+      <v-list-item lines="two">
         <template #prepend>
           <v-avatar :image="banner.metadata.images.logo.url" size="x-large" />
         </template>
 
-        <v-list-item-title class="text-subtitle-1 text-md-h6 font-weight-medium mb-1">
+        <v-list-item-title class="text-subtitle-1 text-md-h6 font-weight-medium">
           <app-markdown
             v-if="banner.metadata.text"
             :content="banner.metadata.text"

--- a/packages/docs/src/components/examples/Example.vue
+++ b/packages/docs/src/components/examples/Example.vue
@@ -209,10 +209,12 @@
     if (!isLoaded.value || isError.value) return null
 
     const resources = JSON.parse(component.value.playgroundResources || '{}')
+    const setup = component.value.playgroundSetup?.trim()
     return usePlayground(
       sections.value,
       resources.css,
       resources.imports,
+      setup,
     )
   })
 

--- a/packages/docs/src/composables/playground.ts
+++ b/packages/docs/src/composables/playground.ts
@@ -14,15 +14,20 @@ function utoa (data: string): string {
 export function usePlayground (
   sections: ({ name: string, content: string, language: string})[] = [],
   css: string[] = [],
-  imports: Record<string, string> = {}
+  imports: Record<string, string> = {},
+  setup?: string,
 ) {
-  const files = {
+  const files: Record<string, string> = {
     'App.vue': sections
       .filter(section => ['script', 'template', 'style'].includes(section.name))
       .map(section => section.content)
       .join('\n\n'),
     'links.json': JSON.stringify({ css }),
     'import-map.json': JSON.stringify({ imports }),
+  }
+
+  if (setup) {
+    files['vuetify.js'] = setup
   }
 
   const hash = utoa(JSON.stringify([files, vueVersion, vuetifyVersion, true]))

--- a/packages/docs/src/examples/v-bottom-navigation/usage.vue
+++ b/packages/docs/src/examples/v-bottom-navigation/usage.vue
@@ -58,19 +58,19 @@
   <v-btn value="recent">
     <v-icon>mdi-history</v-icon>
 
-    Recent
+    <span>Recent</span>
   </v-btn>
 
   <v-btn value="favorites">
     <v-icon>mdi-heart</v-icon>
 
-    Favorites
+    <span>Favorites</span>
   </v-btn>
 
   <v-btn value="nearby">
     <v-icon>mdi-map-marker</v-icon>
 
-    Nearby
+    <span>Nearby</span>
   </v-btn>
 `
 

--- a/packages/docs/src/examples/v-date-picker/guide-locale.vue
+++ b/packages/docs/src/examples/v-date-picker/guide-locale.vue
@@ -5,3 +5,35 @@
     </v-locale-provider>
   </div>
 </template>
+
+<playground-resources lang="json">
+{
+  "imports": {
+    "vuetify/locale": "https://cdn.jsdelivr.net/npm/vuetify/lib/locale/index.mjs/+esm",
+    "@date-io/date-fns": "https://cdn.jsdelivr.net/npm/@date-io/date-fns@2.17.0/build/index.esm.js/+esm",
+    "date-fns/locale/en-US": "https://cdn.jsdelivr.net/npm/date-fns@2.30.0/esm/locale/en-US/index.js/+esm",
+    "date-fns/locale/sv": "https://cdn.jsdelivr.net/npm/date-fns@2.30.0/esm/locale/sv/index.js/+esm"
+  }
+}
+</playground-resources>
+
+<playground-setup>
+import { createVuetify } from 'vuetify'
+import { sv } from 'vuetify/locale'
+import DateFnsAdapter from '@date-io/date-fns'
+import enUS from 'date-fns/locale/en-US'
+import svSE from 'date-fns/locale/sv'
+
+export const vuetify = createVuetify({
+  locale: {
+    messages: { sv },
+  },
+  date: {
+    adapter: DateFnsAdapter,
+    locale: {
+      en: enUS,
+      sv: svSE,
+    },
+  },
+})
+</playground-setup>

--- a/packages/docs/src/layouts/home.vue
+++ b/packages/docs/src/layouts/home.vue
@@ -2,8 +2,6 @@
   <v-app>
     <app-banner />
 
-    <app-v2-banner />
-
     <app-settings-drawer />
 
     <app-bar />
@@ -19,7 +17,6 @@
 <script setup>
   // Components
   import AppBanner from '@/components/app/Banner.vue'
-  import AppV2Banner from '@/components/app/V2Banner.vue'
   import AppBar from '@/components/app/bar/Bar.vue'
   import AppSettingsDrawer from '@/components/app/settings/Drawer.vue'
   import HomeFooter from '@/components/home/Footer.vue'

--- a/packages/docs/src/pages/en/components/bottom-navigation.md
+++ b/packages/docs/src/pages/en/components/bottom-navigation.md
@@ -33,6 +33,12 @@ While `v-bottom navigation` is meant to be used with [vue-router](https://router
 
 <api-inline hide-links />
 
+::: info
+
+For styles to apply properly when using the **shift** prop, `v-btn` text is **required** to be wrapped in a `span` tag.
+
+:::
+
 ## Examples
 
 ### Props

--- a/packages/docs/src/store/banners.ts
+++ b/packages/docs/src/store/banners.ts
@@ -82,13 +82,14 @@ export const useBannersStore = defineStore('banners', {
   },
   getters: {
     banner: state => {
-      const name = state.router.currentRoute.value.name
+      const name = state.router.currentRoute.value.meta.page
 
       return state.banners.find(({ metadata: { visible }, status }) => {
         if (IS_PROD && status !== 'published') return false
 
         if (visible.key === 'both') return true
-        if (visible.key === 'home' && name === 'home') return true
+        // '' is home
+        if (visible.key === 'home' && name === '') return true
 
         return visible.key === 'docs' && name !== 'home'
       })

--- a/packages/docs/vite.config.mts
+++ b/packages/docs/vite.config.mts
@@ -229,6 +229,7 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
         name: 'vuetify:example-blocks',
         transform (code, id) {
           const type = id.includes('vue&type=playground-resources') ? 'playgroundResources'
+            : id.includes('vue&type=playground-setup') ? 'playgroundSetup'
             : null
           if (!type) return
 

--- a/packages/vuetify/src/components/VBottomNavigation/VBottomNavigation.sass
+++ b/packages/vuetify/src/components/VBottomNavigation/VBottomNavigation.sass
@@ -50,6 +50,7 @@
     .v-btn
       &:not(.v-btn--selected)
         .v-btn__content > span
+          transition: inherit
           opacity: 0
 
         .v-btn__content

--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -148,6 +148,9 @@
   &--rounded
     @include tools.rounded($button-rounded-border-radius)
 
+    &.v-btn--icon
+      @include tools.rounded($button-border-radius)
+
   .v-icon
     --v-icon-size-multiplier: #{calc(18/21)}
 

--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -67,7 +67,7 @@
   > .v-avatar
     margin-inline-end: $list-item-avatar-margin-end
 
-  > .v-badge .v-icon,
+  > .v-badge,
   > .v-icon
     margin-inline-end: $list-item-icon-margin-end
 
@@ -83,7 +83,7 @@
   > .v-avatar
     margin-inline-start: $list-item-avatar-margin-start
 
-  > .v-badge .v-icon,
+  > .v-badge,
   > .v-icon
     margin-inline-start: $list-item-icon-margin-start
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

The PR loads the Optimize ad tag from BuySellAds to display ads when Carbon is not returning any paid ads. Since it requires approval from the demands partners, we can only test it on the live domain. It will only show `localhost` is not approved if you try to load the ads locally.

I can test the ads when the update is live. Existing Carbon ads shouldn't be affected because Optimize ad tag only fires when Carbon is not available.